### PR TITLE
update base image and compose commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,36 +1,38 @@
-FROM ubuntu:25.04 AS builder
+FROM golang:1.24.2 AS builder
 
 WORKDIR /app
 
-RUN apt-get update
-RUN apt-get -y install curl gnupg
-RUN curl -sL https://deb.nodesource.com/setup_23.x  | bash -
-RUN apt-get -y install nodejs buildah bats btrfs-progs git go-md2man golang libapparmor-dev libglib2.0-dev libgpgme11-dev libseccomp-dev libselinux1-dev make runc skopeo libbtrfs-dev wget fuse-overlayfs  && rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /etc/containers && \
-    mkdir -p /var/lib/shared/overlay-images /var/lib/shared/overlay-layers && \
-    touch /var/lib/shared/overlay-images/images.lock && \
-    touch /var/lib/shared/overlay-layers/layers.lock
-RUN wget -P /tmp https://go.dev/dl/go1.24.1.linux-arm64.tar.gz
-RUN tar -C /usr/local -xzf "/tmp/go1.24.1.linux-arm64.tar.gz"
-RUN rm "/tmp/go1.24.1.linux-arm64.tar.gz"
+RUN apt-get update && apt-get -y install --no-install-recommends \
+    buildah \
+    gnupg \
+    btrfs-progs \
+    bats \
+    libapparmor-dev \
+    libglib2.0-dev \
+    libgpgme11-dev \
+    libseccomp-dev \
+    libselinux1-dev \
+    runc \
+    skopeo \
+    libbtrfs-dev \
+    fuse-overlayfs \
+    && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && apt-get -y install --no-install-recommends nodejs \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
-ENV GOPATH /go
-ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
-RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
+COPY policy.json storage.conf registries.conf /etc/containers/
 
 RUN mkdir -p /etc/containers/ && touch /etc/containers/registries.conf && echo 'unqualified-search-registries=["docker.io"]' > /etc/containers/registries.conf
-COPY policy.json /etc/containers/policy.json
-COPY storage.conf /etc/containers/storage.conf 
-COPY registries.conf /etc/containers/registries.conf 
+
+COPY policy.json storage.conf registries.conf /etc/containers/
 
 # # Disable CGO to ensure fully static binaries
-# ENV CGO_ENABLED=0 
+# ENV CGO_ENABLED=0
 # ENV GOOS=linux
 
-COPY go.mod go.mod
-COPY go.sum go.sum
+COPY go.mod go.sum ./
 RUN --mount=type=cache,target=/go/pkg/mod/ go mod download -x
-
 
 FROM builder AS dev
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,6 @@ RUN apt-get update && apt-get -y install --no-install-recommends \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-COPY policy.json storage.conf registries.conf /etc/containers/
-
 RUN mkdir -p /etc/containers/ && touch /etc/containers/registries.conf && echo 'unqualified-search-registries=["docker.io"]' > /etc/containers/registries.conf
 
 COPY policy.json storage.conf registries.conf /etc/containers/

--- a/Makefile
+++ b/Makefile
@@ -44,19 +44,19 @@ migrate_v:
 	migrate -path migrations -database ${DB_DSN} version
 
 start-e2e-test-env:
-	docker-compose -p treenq -f docker-compose.yaml -f docker-compose.e2e.yaml up kube -d 
+	COMPOSE_BAKE=true docker compose -p treenq -f docker-compose.yaml -f docker-compose.e2e.yaml up kube -d 
 	sleep 1
 	$(SED) 's#https://127.0.0.1:6443#https://kube:6443#g' k3s_data/k3s/k3s.yaml
-	docker-compose -p treenq -f docker-compose.yaml -f docker-compose.e2e.yaml up -d --build
+	COMPOSE_BAKE=true docker compose -p treenq -f docker-compose.yaml -f docker-compose.e2e.yaml up -d --build
 	while [ -z '$$(docker ps -q --filter "name=treenq-server")' ]; do sleep 1; done	
 	docker cp k3s_data/k3s/k3s.yaml $$(docker ps -q --filter "name=treenq-server"):/app/kubeconfig.yaml
-	docker-compose -p treenq -f docker-compose.yaml -f docker-compose.e2e.yaml restart server 
+	COMPOSE_BAKE=true docker compose -p treenq -f docker-compose.yaml -f docker-compose.e2e.yaml restart server 
 	@echo "Checking e2e test environment is running..."
 	until $$(curl --output /dev/null --silent --fail http://localhost:8000/healthz); do printf '.'; sleep 1; done && echo "Service Ready!"
 	echo 'Service has been started'
 
 stop-e2e-test-env:
-	docker-compose -f docker-compose.yaml -f docker-compose.e2e.yaml down
+	docker compose -f docker-compose.yaml -f docker-compose.e2e.yaml down
 
 run-e2e-tests: start-e2e-test-env
 	go test -v -count=1 -race ./e2e/...


### PR DESCRIPTION
* Update base image from ubuntu:25.04 to golang:1.24.2
* Optimize apt-get installations with single layer and cleanup
* Update Node.js installation from v23 to v20 LTS
* Simplify container configuration file copying
* Modernize docker-compose commands to use docker compose v2

combining the commands + cleaning into one layer, make the layer smaller, that's why I grouped stuff together