### PR TITLE
add postgres web UI for local development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,5 +62,8 @@ run-e2e-tests: start-e2e-test-env
 	go test -v -count=1 -race ./e2e/...
 	make stop-e2e-test-env
 
+start-local-tools:
+	COMPOSE_BAKE=true docker compose -p treenq -f docker-compose.local.yaml up -d --build
+
 unit-tests:
 	go test $$(go list ./... | grep -v e2e)

--- a/docker-compose.local.yaml
+++ b/docker-compose.local.yaml
@@ -1,0 +1,8 @@
+services:
+  postgres-ui:
+    image: sosedoff/pgweb:0.16.2
+    environment:
+      - PGWEB_DATABASE_URL=postgres://postgres@postgres:5432/tq?sslmode=disable
+    ports:
+      - 8082:8081
+    restart: on-failure


### PR DESCRIPTION
Adds pgweb as a development tool to inspect postgres database through web interface. New make target 'start-local-tools' spins up development tools using docker-compose.

![image](https://github.com/user-attachments/assets/2008ea39-fc6d-4661-997e-9b8f7c98338a)
