### PR TITLE
feat: Implement remove secret functionality and restyle actions

### DIFF
--- a/web/src/components/widgets/Secrets.tsx
+++ b/web/src/components/widgets/Secrets.tsx
@@ -76,7 +76,7 @@ const SecretTableRow = ({
           />
         </TextField>
         <Show when={type === 'edit'}>
-          <Button onClick={() => (visible() ? setVisible(false) : toggleVisible())}>
+          <Button variant="ghost" size="icon" onClick={() => (visible() ? setVisible(false) : toggleVisible())}>
             <Show when={visible()} fallback={<Eye />}>
               <EyeOff />
             </Show>
@@ -118,7 +118,15 @@ const SecretRow = ({ repoID, secret, index, setSecrets }: SecretRowProps) => {
     }
   }
 
-  const deleteSecret = () => setSecrets((secrets) => secrets.filter((_, i) => i !== index))
+  const deleteSecret = async () => {
+    const res = await httpClient.removeSecret({ repoID, key: secret().key })
+    if (!res.error) {
+      setSecrets((secrets) => secrets.filter((_, i) => i !== index))
+    } else {
+      // TODO: better error handling
+      console.error('Failed to delete secret:', res.error)
+    }
+  }
 
   return (
     <SecretTableRow
@@ -132,10 +140,10 @@ const SecretRow = ({ repoID, secret, index, setSecrets }: SecretRowProps) => {
       type="edit"
     >
       <div class="flex space-x-2">
-        <Show when={isEditing()} fallback={<Button onClick={toggleEditMode}>Edit</Button>}>
-          <Button onClick={updateSecret}>Save</Button>
+        <Show when={isEditing()} fallback={<Button variant="outline" onClick={toggleEditMode}>Edit</Button>}>
+          <Button variant="default" onClick={updateSecret}>Save</Button>
         </Show>
-        <Button onClick={deleteSecret}>Delete</Button>
+        <Button variant="destructive" onClick={deleteSecret}>Delete</Button>
       </div>
     </SecretTableRow>
   )

--- a/web/src/services/client.ts
+++ b/web/src/services/client.ts
@@ -102,6 +102,8 @@ export type RevealSecretRequest = { repoID: string; key: string }
 
 export type RevealSecretResponse = { value: string }
 
+export type RemoveSecretRequest = { repoID: string; key: string }
+
 export type GetBuildProgressMessage = {
   message: BuildProgressMessage
 }
@@ -224,6 +226,10 @@ class HttpClient {
 
   async revealSecret(req: RevealSecretRequest): Promise<Result<RevealSecretResponse>> {
     return await this.post('revealSecret', req)
+  }
+
+  async removeSecret(req: RemoveSecretRequest): Promise<Result<void>> {
+    return await this.post<void>('removeSecret', req)
   }
 
   async getDeployment(req: GetDeploymentRequest): Promise<Result<GetDeploymentResponse>> {


### PR DESCRIPTION
Implements the `removeSecret` API client method and integrates it into the secrets widget. This allows you to delete secrets from the UI.

Additionally, the action buttons in the secrets widget have been restyled:
- Edit button now uses an outline style.
- Reveal secret button is now an icon-style button.
- Delete button uses a destructive style.
- Save (edit confirmation) button uses the primary style.